### PR TITLE
Fix parent index in `bubble_up` become Float64

### DIFF
--- a/src/priority_queue.cr
+++ b/src/priority_queue.cr
@@ -146,7 +146,7 @@ class PriorityQueue(P, T)
   private def bubble_up(index)
     return if index == 0
 
-    parent_index = (index - 1) / 2
+    parent_index = (index - 1) >> 1
     return if @elements[parent_index] >= @elements[index]
 
     exchange(index, parent_index)


### PR DESCRIPTION
When testing the priority queue:
```crystal
require "priority_queue"

queue = PriorityQueue(Int32, String).new
queue[2] = "Two"
```
It tosses this error:
```
In lib/priority_queue/src/priority_queue.cr:150:25

 150 | return if @elements[parent_index] >= @elements[index]
                           ^-----------
Error: expected argument #1 to 'Array(PriorityQueue::Element(Int32, String))#[]' to be Int or Range(B, E), not Float64
```

After looking at the source code, seems like in `#bubble_up` method, this line `parent_index = (index - 1) / 2` always return a `Float64`.

This PR:
Replace division operator with bit-shift operator to keep it as `Int`. 